### PR TITLE
Changed CMake minimum required version to 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.14)
 
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
     message(FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt. ")


### PR DESCRIPTION
## 概要

`FetchContent_MakeAvailable()`は、 CMake 3.14以降で利用することが出来ます。
このプロジェクトでは、GoogleTestやjp2aを取得した際に利用しているため、CMakeでビルドを実行できる最小のバージョンを3.14に引き上げました。