### PR TITLE
Fix CMake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@ FetchContent_Declare(
 if(WIN32)
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 endif(WIN32)
+
+# We don't want to install GoogleTest libs when we run `cmake --install`
+set(INSTALL_GTEST OFF CACHE BOOL "Enable installation of GoogleTest." FORCE)
+
 FetchContent_MakeAvailable(googletest)
 
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,11 @@ FetchContent_Declare(
     googletest
     URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
 )
+
 # For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+if(WIN32)
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+endif(WIN32)
 FetchContent_MakeAvailable(googletest)
 
 enable_testing()


### PR DESCRIPTION
## 概要

以下の2つのオプションを修正しました。

- `gtest_force_shared_crt`: Windowsのときのみ `ON` にする。LinuxやmacOS向けで、`ON`であることによる問題は見られていませんが、変更する必要がない場合は変更しない方が良いと思います
- `INSTALL_GTEST`: `cmake --install`時にGoogleTest関連のヘッダファイルなどもインストールされてしまう問題を修正します。
	- https://github.com/google/googletest/blob/5ab508a01f9eb089207ee87fd547d290da39d015/CMakeLists.txt#L32
	- によると、GoogleTestを利用するプロジェクト側では `OFF` にすると良いことが書かれていました